### PR TITLE
Update VideoEngineCallbackDemo.java

### DIFF
--- a/src/main/java/uk/co/caprica/vlcj/lwjgl/demo/VideoEngineCallbackDemo.java
+++ b/src/main/java/uk/co/caprica/vlcj/lwjgl/demo/VideoEngineCallbackDemo.java
@@ -175,7 +175,7 @@ public class VideoEngineCallbackDemo {
                 @Override
                 public void invoke(long window, int width, int height) {
                     try {
-                        if (!contextSemaphore.tryAcquire()) {
+                        if (!contextSemaphore.tryAcquire(1, TimeUnit.SECONDS)) {
                             return;
                         }
                         glfwMakeContextCurrent(window);

--- a/src/main/java/uk/co/caprica/vlcj/lwjgl/demo/VideoEngineCallbackDemo.java
+++ b/src/main/java/uk/co/caprica/vlcj/lwjgl/demo/VideoEngineCallbackDemo.java
@@ -182,7 +182,7 @@ public class VideoEngineCallbackDemo {
                     }
                     catch (InterruptedException e) {
                         return;
-                    } 
+                    }
                     catch (Exception e) {
                         glfwMakeContextCurrent(0);
                         contextSemaphore.release();

--- a/src/main/java/uk/co/caprica/vlcj/lwjgl/demo/VideoEngineCallbackDemo.java
+++ b/src/main/java/uk/co/caprica/vlcj/lwjgl/demo/VideoEngineCallbackDemo.java
@@ -79,7 +79,7 @@ public class VideoEngineCallbackDemo {
     /**
      * Semaphore used to synchronise the GL context - the context can only be active on one thread at a time.
      */
-    private final Semaphore contextSemaphore = new Semaphore(0);
+    private final Semaphore contextSemaphore = new Semaphore(0, true);
 
     /**
      * Media player factory.
@@ -175,11 +175,10 @@ public class VideoEngineCallbackDemo {
                 @Override
                 public void invoke(long window, int width, int height) {
                     try {
-                        contextSemaphore.acquire();
+                        if (!contextSemaphore.tryAcquire()) {
+                            return;
+                        }
                         glfwMakeContextCurrent(window);
-                    }
-                    catch (InterruptedException e) {
-                        return;
                     }
                     catch (Exception e) {
                         glfwMakeContextCurrent(0);

--- a/src/main/java/uk/co/caprica/vlcj/lwjgl/demo/VideoEngineCallbackDemo.java
+++ b/src/main/java/uk/co/caprica/vlcj/lwjgl/demo/VideoEngineCallbackDemo.java
@@ -180,6 +180,9 @@ public class VideoEngineCallbackDemo {
                         }
                         glfwMakeContextCurrent(window);
                     }
+                    catch (InterruptedException e) {
+                        return;
+                    } 
                     catch (Exception e) {
                         glfwMakeContextCurrent(0);
                         contextSemaphore.release();


### PR DESCRIPTION
This should fix #1 

#1 is caused by the call to `contextSemaphore.acquire()`; in L178, that seems to be executed before the Semaphore is released somewhere else. By replacing that call with `tryAcquire()` and a return if not possible, it skips the first execution, leading to the example being able to run on windows. (Seems to be caused by a bit different native implementations of the library.)

<del> I'll still have to look at a few Semaphore options, as this may lead to a few unwanted site effects in performance.</del>  Fixed. 